### PR TITLE
builder for get_current_era

### DIFF
--- a/test/xander/messages_test.exs
+++ b/test/xander/messages_test.exs
@@ -1,0 +1,5 @@
+defmodule Xander.MessagesTest do
+  use ExUnit.Case
+
+  doctest Xander.Messages
+end


### PR DESCRIPTION
Builds a get_current_era message dynamically in plain CBOR from reusable message helpers that reflect the Ouroborous network specification.