### PR TITLE
Get current tip

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}", "*.exs"]
 ]

--- a/lib/xander/messages.ex
+++ b/lib/xander/messages.ex
@@ -14,6 +14,7 @@ defmodule Xander.Messages do
   @get_current_block_height [2]
   @get_current_era [0, [2, [1]]]
   @get_epoch_number [0, [0, [6, [1]]]]
+  @get_current_tip [3]
 
   # See the CDDL for details on mapping of messages to numbers.
   # https://github.com/IntersectMBO/ouroboros-network/blob/main/ouroboros-network-protocols/cddl/specs/local-state-query.cddl
@@ -106,6 +107,27 @@ defmodule Xander.Messages do
   """
   def get_epoch_number do
     payload = build_query(@get_epoch_number)
+    bitstring_payload = CBOR.encode(payload)
+
+    header(@mini_protocols.local_state_query, bitstring_payload) <> bitstring_payload
+  end
+
+  @doc """
+  Builds a static query to get the current tip of the chain
+
+  Payload CBOR: [3]
+  Payload Bitstring: <<129, 3>>
+
+  ## Examples
+
+    iex> <<_timestamp::32, msg::binary>> = Xander.Messages.get_current_tip()
+    iex> msg
+    <<0, 7, 0, 4, 130, 3, 129, 3>>
+
+  """
+  @spec get_current_tip() :: binary()
+  def get_current_tip do
+    payload = build_query(@get_current_tip)
     bitstring_payload = CBOR.encode(payload)
 
     header(@mini_protocols.local_state_query, bitstring_payload) <> bitstring_payload

--- a/lib/xander/query.ex
+++ b/lib/xander/query.ex
@@ -135,6 +135,7 @@ defmodule Xander.Query do
         :get_current_era -> Messages.get_current_era()
         :get_current_block_height -> Messages.get_current_block_height()
         :get_epoch_number -> Messages.get_epoch_number()
+        :get_current_tip -> Messages.get_current_tip()
       end
 
     :ok = client.send(socket, message)

--- a/lib/xander/query/response.ex
+++ b/lib/xander/query/response.ex
@@ -19,11 +19,17 @@ defmodule Xander.Query.Response do
     {:ok, {slot_number, block_hash}}
   end
 
-  # For get_current_block_height
-  defp parse_cbor([@message_response, [@slot_timeline, response]]) do
-    {:ok, response}
+  # This clause parses the response from the get_current_block_height query
+  defp parse_cbor([@message_response, [@slot_timeline, block_height]]) do
+    {:ok, block_height}
   end
 
+  # This clause parses the response from get_epoch_number
+  defp parse_cbor([@message_response, [epoch_number]]) do
+    {:ok, epoch_number}
+  end
+
+  # This clause parses the response from all other queries
   defp parse_cbor([@message_response, response]) do
     {:ok, response}
   end

--- a/lib/xander/query/response.ex
+++ b/lib/xander/query/response.ex
@@ -13,6 +13,12 @@ defmodule Xander.Query.Response do
     end
   end
 
+  # This clause parses the response from the get_current_tip query
+  defp parse_cbor([@message_response, [slot_number, %CBOR.Tag{tag: :bytes, value: response}]]) do
+    block_hash = Base.encode16(response, case: :lower)
+    {:ok, {slot_number, block_hash}}
+  end
+
   # For get_current_block_height
   defp parse_cbor([@message_response, [@slot_timeline, response]]) do
     {:ok, response}

--- a/run.exs
+++ b/run.exs
@@ -20,7 +20,8 @@ config = Config.default_config!(socket_path)
 queries = [
   :get_epoch_number,
   :get_current_era,
-  :get_current_block_height
+  :get_current_block_height,
+  :get_current_tip
 ]
 
 case Query.start_link(config) do

--- a/run_with_demeter.exs
+++ b/run_with_demeter.exs
@@ -23,7 +23,8 @@ config = Config.demeter_config!(demeter_url, network: network)
 queries = [
   :get_epoch_number,
   :get_current_era,
-  :get_current_block_height
+  :get_current_block_height,
+  :get_current_tip
 ]
 
 case Query.start_link(config) do


### PR DESCRIPTION
Returns a 2-element tuple with values for slot number and block hash.

Via unix socket:

```bash
➜ CARDANO_NODE_SOCKET_PATH=/tmp/cardano-node.socket elixir run.exs
Successfully connected to Cardano node
Query get_current_tip result: {147646823, "60d86f122bc688cfbc95339120038b06ba8585e74c02c514ebb9679e6f74e469"}
```

Via Demeter.run:

```bash
➜ DEMETER_URL=https://...demeter.run elixir run_with_demeter.exs
Successfully connected to Demeter node
Query get_current_tip result: {147646929, "9ca69ebd58a306096457d251adc197bb5fe99397502583996cb4bb95f091da2f"}
```