### PR TITLE
Issue release message after response.

### DIFF
--- a/lib/xander/query.ex
+++ b/lib/xander/query.ex
@@ -1,7 +1,7 @@
 defmodule Xander.Query do
   @moduledoc """
   Issues ledger queries to a Cardano node using the Node-to-Client (n2c) protocol.
-  This module implements the `gen_statem` behaviour.
+  This module implements the `gen_statem` OTP behaviour.
   """
 
   @behaviour :gen_statem
@@ -133,12 +133,12 @@ defmodule Xander.Query do
         Handshake.Proposal.version_message(@active_n2c_versions, network)
       )
 
-    case client.recv(socket, 0, 5_000) do
+    case client.recv(socket, 0, _timeout = 5_000) do
       {:ok, full_response} ->
         {:ok, _handshake_response} = Handshake.Response.validate(full_response)
 
-        actions = [{:next_event, :internal, :acquire_agency}]
-        {:next_state, :established_no_agency, data, actions}
+        # Transitions to idle state
+        {:next_state, :established_no_agency, data}
 
       {:error, reason} ->
         Logger.error("Error establishing connection #{inspect(reason)}")
@@ -148,81 +148,107 @@ defmodule Xander.Query do
 
   @doc """
   Emits events when in the `established_no_agency` state.
+  This maps to the StIdle state in the Cardano Local State Query protocol.
+  This is the state where the process waits for a query to be made.
   """
   def established_no_agency(_event_type, _event_content, _data)
 
   def established_no_agency(
-        :internal,
-        :acquire_agency,
+        {:call, from},
+        {:request, query_name},
         %__MODULE__{client: client, socket: socket} = data
       ) do
+    # Send acquire message to transition to Acquiring state
     :ok = client.send(socket, Messages.msg_acquire())
-    {:ok, _acquire_response} = client.recv(socket, 0, 5_000)
-    {:next_state, :established_has_agency, data}
-  end
 
-  def established_no_agency(
-        :internal,
-        :release_message,
-        %__MODULE__{client: client, socket: socket} = data
-      ) do
-    _ok = client.send(socket, Messages.msg_release())
+    # Handle acquire response (MsgAcquired) to transition to Acquired state
+    case client.recv(socket, 0, _timeout = 5_000) do
+      {:ok, _acquire_response} ->
+        # Set socket to active mode to receive async messages from node
+        :ok = setopts_lib(client).setopts(socket, active: :once)
 
-    actions = [{:next_event, :internal, :acquire_agency}]
-    {:next_state, :established_no_agency, data, actions}
+        # Track the caller and query_name, then transition to
+        # established_has_agency state prior to sending the query.
+        data = update_in(data.queue, &:queue.in({from, query_name}, &1))
+        {:next_state, :established_has_agency, data, [{:next_event, :internal, :send_query}]}
+
+      {:error, reason} ->
+        Logger.error("Failed to acquire state: #{inspect(reason)}")
+        actions = [{:reply, from, {:error, :acquire_failed}}]
+        {:keep_state, data, actions}
+    end
   end
 
   def established_no_agency(:info, {:tcp_closed, socket}, %__MODULE__{socket: socket} = data) do
-    Logger.error("Connection closed")
+    Logger.error("Connection closed while in established_no_agency")
     {:next_state, :disconnected, data}
   end
 
   @doc """
-  Emits events when in the `established_has_agency` state. Can send queries
-  to the node when in this state.
+  Emits events when in the `established_has_agency` state.
+  This maps to the Querying state in the Cardano Local State Query protocol.
   """
   def established_has_agency(_event_type, _event_content, _data)
 
   def established_has_agency(
-        {:call, from},
-        {:request, request},
+        :internal,
+        :send_query,
         %__MODULE__{client: client, socket: socket} = data
       ) do
-    :ok = setopts_lib(client).setopts(socket, active: :once)
+    # Get the current query_name from queue without removing it
+    {:value, {_from, query_name}} = :queue.peek(data.queue)
 
-    message =
-      case request do
-        :get_current_era -> Messages.get_current_era()
-        :get_current_block_height -> Messages.get_current_block_height()
-        :get_epoch_number -> Messages.get_epoch_number()
-        :get_current_tip -> Messages.get_current_tip()
-      end
-
-    :ok = client.send(socket, message)
-    data = update_in(data.queue, &:queue.in(from, &1))
+    # Send query to node and remain in established_has_agency state
+    :ok = client.send(socket, build_query_message(query_name))
     {:keep_state, data}
   end
 
+  # This function is invoked due to the socket being set to active mode.
+  # It receives a response from the node, sends a release message and
+  # then transitions back to the established_no_agency state.
   def established_has_agency(
         :info,
         {_tcp_or_ssl, socket, bytes},
-        %__MODULE__{socket: socket} = data
+        %__MODULE__{client: client, socket: socket} = data
       ) do
-    {:ok, query_response} = Response.parse_response(bytes)
-    {{:value, caller}, data} = get_and_update_in(data.queue, &:queue.out/1)
+    # Parse query response (MsgResult)
+    case Response.parse_response(bytes) do
+      {:ok, query_response} ->
+        # Get the caller from our queue
+        {{:value, {caller, _query_name}}, new_data} = get_and_update_in(data.queue, &:queue.out/1)
 
-    # Reply to caller and trigger release_message action in the new state
-    actions = [
-      {:reply, caller, {:ok, query_response}},
-      {:next_event, :internal, :release_message}
-    ]
+        # Send release message to transition back to StIdle
+        :ok = client.send(socket, Messages.msg_release())
 
-    {:next_state, :established_no_agency, data, actions}
+        # Reply to caller and transition back to established_no_agency (StIdle)
+        actions = [{:reply, caller, {:ok, query_response}}]
+        {:next_state, :established_no_agency, new_data, actions}
+
+      {:error, reason} ->
+        Logger.error("Failed to parse response: #{inspect(reason)}")
+        {{:value, {caller, _query_name}}, new_data} = get_and_update_in(data.queue, &:queue.out/1)
+        actions = [{:reply, caller, {:error, :parse_failed}}]
+        {:next_state, :established_no_agency, new_data, actions}
+    end
   end
 
   def established_has_agency(:info, {:tcp_closed, socket}, %__MODULE__{socket: socket} = data) do
-    Logger.error("Connection closed")
+    Logger.error("Connection closed while querying")
     {:next_state, :disconnected, data}
+  end
+
+  def established_has_agency(:timeout, _event_content, data) do
+    Logger.error("Query timeout")
+    {:next_state, :established_no_agency, data}
+  end
+
+  defp build_query_message(query_name) do
+    case query_name do
+      :get_current_era -> Messages.get_current_era()
+      :get_current_block_height -> Messages.get_current_block_height()
+      :get_epoch_number -> Messages.get_epoch_number()
+      :get_current_tip -> Messages.get_current_tip()
+    end
   end
 
   defp maybe_local_path(path, :socket), do: {:local, path}


### PR DESCRIPTION
This fixes an issue where the ledger state tracked by the `Query` OTP process wouldn't be updated after establishing a connection. The result was that queries would always return the same value.

![image](https://github.com/user-attachments/assets/3265b14b-6c4a-4cf8-90db-fc03f9b864c7)

(_left: Xogmios with updated result, right: Xander always with the same result_)

This PR re-writes the states and transitions so that ledger state is always acquired prior to each query being run. This ensures that the query will be performed against the most up-to-date version of the ledger.


<img width="878" alt="Alacritty" src="https://github.com/user-attachments/assets/0fbd8353-6ee2-4962-a5bc-403f1615e280" />

(_notice the result now changes_)
