### PR TITLE
add config support for yaci devkit

### DIFF
--- a/lib/xander/config.ex
+++ b/lib/xander/config.ex
@@ -60,8 +60,9 @@ defmodule Xander.Config do
 
   # Validates and normalizes the configuration options.
   defp validate_config!(opts) do
-    if opts[:network] not in [:mainnet, :preprod, :preview, :sanchonet] do
-      raise ArgumentError, "network must be :mainnet, :preprod, :preview, or :sanchonet"
+    if opts[:network] not in [:mainnet, :preprod, :preview, :sanchonet, :yaci_devkit] do
+      raise ArgumentError,
+            "network must be :mainnet, :preprod, :preview, :sanchonet, or :yaci_devkit"
     end
 
     if opts[:type] not in [:socket, :ssl] do

--- a/lib/xander/handshake/proposal.ex
+++ b/lib/xander/handshake/proposal.ex
@@ -3,13 +3,14 @@ defmodule Xander.Handshake.Proposal do
   Builds handshake messages for node-to-client communication.
   """
 
-  @type network_type :: :mainnet | :preprod | :preview | :sanchonet
+  @type network_type :: :mainnet | :preprod | :preview | :sanchonet | :yaci_devkit
 
   @network_magic [
     mainnet: 764_824_073,
     preprod: 1,
     preview: 2,
-    sanchonet: 4
+    sanchonet: 4,
+    yaci_devkit: 42
   ]
 
   @version_numbers %{


### PR DESCRIPTION
The [yaci-devkit](https://github.com/bloxbean/yaci-devkit?tab=readme-ov-file#whats-yaci-devkit) local chain uses `42` as the network magic value. This supports the config for that value under the `yaci_devkit` tag.