### PR TITLE
Read message Mode from multiplexer

### DIFF
--- a/lib/chain_sync.ex
+++ b/lib/chain_sync.ex
@@ -216,6 +216,7 @@ defmodule Xander.ChainSync do
     emit_initial_next_message = fn client, socket ->
       with :ok <- client.send(socket, Messages.next_request()),
            {:ok, header_bytes} <- client.recv(socket, 8, @recv_timeout),
+           # TODO: use Util.plex!
            <<_timestamp::big-32, _mode::1, _protocol_id::15, payload_length::big-16>> <-
              header_bytes,
            {:ok, payload} <- client.recv(socket, payload_length, @recv_timeout) do
@@ -364,6 +365,7 @@ defmodule Xander.ChainSync do
     # Read the header (8 bytes)
     case client.recv(socket, 8, @recv_timeout) do
       {:ok, header_bytes} ->
+        # TODO: use Util.plex!
         <<_timestamp::big-32, _mode::1, _protocol_id::15, payload_length::big-16>> = header_bytes
 
         case client.recv(socket, payload_length, @recv_timeout) do
@@ -424,6 +426,7 @@ defmodule Xander.ChainSync do
     # Read another header
     case client.recv(socket, 8, @recv_timeout) do
       {:ok, header_bytes} ->
+        # TODO: use Util.plex!
         <<_timestamp::big-32, _mode::1, _protocol_id::15, payload_length::big-16>> = header_bytes
 
         # Read another payload

--- a/lib/xander/util.ex
+++ b/lib/xander/util.ex
@@ -5,15 +5,27 @@ defmodule Xander.Util do
 
   ## Examples
 
-      iex> Xander.Util.plex(<<0, 0, 0, 0, 1, 2, 0, 3, 97, 98, 99>>)
-      {:ok, %{size: 3, payload: "abc", protocol_id: 258}}
+      iex> Xander.Util.plex(<<0, 0, 0, 0, 0, 7, 0, 3, 97, 98, 99>>)
+      {:ok, %{mode: 0, protocol_id: 7, size: 3, payload: "abc"}}
 
   """
   @spec plex(binary() | nil) :: {:ok, map()} | {:error, atom()}
   def plex(msg) when is_binary(msg) and byte_size(msg) >= 8 do
-    <<_timestamp::big-32, protocol_id::big-16, payload_size::big-16, payload::binary>> = msg
+    <<
+      _timestamp::big-32,
+      mode::1,
+      protocol_id::15,
+      payload_size::big-16,
+      payload::binary
+    >> = msg
 
-    {:ok, %{payload: payload, protocol_id: protocol_id, size: payload_size}}
+    {:ok,
+     %{
+       mode: mode,
+       payload: payload,
+       protocol_id: protocol_id,
+       size: payload_size
+     }}
   end
 
   def plex(msg) when is_binary(msg) do
@@ -30,8 +42,8 @@ defmodule Xander.Util do
 
   ## Examples
 
-      iex> Xander.Util.plex!(<<0, 0, 0, 0, 1, 2, 0, 3, 97, 98, 99>>)
-      %{payload: "abc", protocol_id: 258, size: 3}
+      iex> Xander.Util.plex!(<<0, 0, 0, 0, 0, 7, 0, 3, 97, 98, 99>>)
+      %{mode: 0, protocol_id: 7, size: 3, payload: "abc"}
 
   """
   @spec plex!(binary()) :: map()


### PR DESCRIPTION
This properly accounts for the Mode bit in the multiplexer and correctly reads the protocol id. 

> The single bit M (the mode) is used to distinguish the dual instances of a mini-protocol. The mode is set to 0 in segments from the initiator, i.e. the side that initially has agency and 1 in segments from the responder.

See wire format below from the spec where `M` is represented by the first bit and the mini protocol ID by the following 15 bits.

<img width="882" height="274" alt="2025-network-spec_pdf" src="https://github.com/user-attachments/assets/320a080b-08ac-4149-a290-767eaebd7a87" />

Added TODOs for us to replace the manual reading of the bytes in favor of this `Xander.Util.plex!` function.