### PR TITLE
Update module state for handle_block

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,11 @@ For a more detailed description of different ways to use this library, read the 
   docker run --rm -e DEMETER_URL=https://your-node-at.demeter.run xander elixir run_chain_sync_with_demeter.exs
   ```
 </details>
+
+## Testing
+
+The integration tests are built upon [Yaci Devkit](https://github.com/bloxbean/yaci-devkit) and can be run locally with [nektos/act](https://github.com/nektos/act) like so:
+
+```
+act -j integration_test
+```

--- a/lib/chain_sync.ex
+++ b/lib/chain_sync.ex
@@ -301,7 +301,7 @@ defmodule Xander.ChainSync do
                    },
                    state
                  ) do
-              {:ok, :next_block, _new_state} ->
+              {:ok, :next_block, new_state} ->
                 :ok = client.send(socket, Messages.next_request())
 
                 {:ok, data} = client.recv(socket, 8, @recv_timeout)
@@ -315,17 +315,17 @@ defmodule Xander.ChainSync do
                   {:ok, %AwaitReply{}} ->
                     # Response should always be [1] msgAwaitReply
                     :ok = setopts_lib(client).setopts(socket, active: :once)
-                    :keep_state_and_data
+                    {:keep_state, %{module_state | state: new_state}}
 
                   error ->
                     Logger.warning("Error decoding next request: #{inspect(error)}")
-                    :keep_state_and_data
+                    {:keep_state, %{module_state | state: new_state}}
                 end
 
-              {:close, _new_state} ->
+              {:close, new_state} ->
                 Logger.debug("Disconnecting from node")
                 :ok = client.close(socket)
-                {:next_state, :disconnected, module_state}
+                {:next_state, :disconnected, %{module_state | state: new_state}}
             end
 
           {:ok, %RollBackward{point: point}} ->
@@ -340,10 +340,10 @@ defmodule Xander.ChainSync do
                    },
                    state
                  ) do
-              {:ok, :next_block, _new_state} ->
+              {:ok, :next_block, new_state} ->
                 :ok = client.send(socket, Messages.next_request())
                 :ok = setopts_lib(client).setopts(socket, active: :once)
-                :keep_state_and_data
+                {:keep_state, %{module_state | state: new_state}}
 
               {:ok, :stop} ->
                 {:next_state, :disconnected, module_state}
@@ -406,14 +406,14 @@ defmodule Xander.ChainSync do
                        },
                        state
                      ) do
-                  {:ok, :next_block, _new_state} ->
+                  {:ok, :next_block, new_state} ->
                     :ok = client.send(socket, Messages.next_request())
-                    read_until_sync(client, socket, client_module, state)
+                    read_until_sync(client, socket, client_module, new_state)
 
-                  {:close, _new_state} ->
+                  {:close, new_state} ->
                     Logger.debug("Disconnecting from node")
                     :ok = client.close(socket)
-                    {:next_state, :disconnected, state}
+                    {:next_state, :disconnected, new_state}
                 end
 
               {:error, :incomplete_cbor_data} ->
@@ -454,9 +454,9 @@ defmodule Xander.ChainSync do
                        },
                        state
                      ) do
-                  {:ok, :next_block, _new_state} ->
+                  {:ok, :next_block, new_state} ->
                     :ok = client.send(socket, Messages.next_request())
-                    read_until_sync(client, socket, client_module, state)
+                    read_until_sync(client, socket, client_module, new_state)
 
                   {:ok, :stop} ->
                     :ok


### PR DESCRIPTION
Merges updates from handle_block/2  into `module_state.state`  when new blocks are received.

Also adds instructions for running integration tests to the README.