### PR TITLE
Fix mode and mini-protocol id values in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 accounts for the Mode bit in the multiplexer which fixes the reading of
 protocol ID.
 
+- Fix multiplexer header for outgoing messages. Properly setting the Mode as 1
+bit and the mini protocol ID as 15 bits.
+
 ## [v0.3.0](https://github.com/wowica/xander/releases/tag/v0.3.0) (2025-08-14)
 
 ### Added

--- a/lib/xander/messages.ex
+++ b/lib/xander/messages.ex
@@ -190,7 +190,12 @@ defmodule Xander.Messages do
 
   # middle 16 bits are: 1 bit == 0 for initiator and 15 bits for the mini protocol ID
   defp header(mini_protocol_id, payload),
-    do: <<header_timestamp()::big-32, 0::1, mini_protocol_id::15, byte_size(payload)::big-16>>
+    do: <<
+      header_timestamp()::big-32,
+      0::1,
+      mini_protocol_id::15,
+      byte_size(payload)::big-16
+    >>
 
   # Returns the lower 32 bits of the system's monotonic time in microseconds
   defp header_timestamp,

--- a/lib/xander/messages.ex
+++ b/lib/xander/messages.ex
@@ -190,8 +190,7 @@ defmodule Xander.Messages do
 
   # middle 16 bits are: 1 bit == 0 for initiator and 15 bits for the mini protocol ID
   defp header(mini_protocol_id, payload),
-    do:
-      <<header_timestamp()::32>> <> <<0, mini_protocol_id>> <> <<byte_size(payload)::unsigned-16>>
+    do: <<header_timestamp()::big-32, 0::1, mini_protocol_id::15, byte_size(payload)::big-16>>
 
   # Returns the lower 32 bits of the system's monotonic time in microseconds
   defp header_timestamp,


### PR DESCRIPTION
Mode should be 1 bit and mini protocol id should be 15 bits.
Other values remain the same just making big endian syntax consistent.