### PR TITLE
Already being set prior to sending query.

### DIFF
--- a/lib/xander/query.ex
+++ b/lib/xander/query.ex
@@ -164,9 +164,6 @@ defmodule Xander.Query do
     # Handle acquire response (MsgAcquired) to transition to Acquired state
     case client.recv(socket, 0, _timeout = 5_000) do
       {:ok, _acquire_response} ->
-        # Set socket to active mode to receive async messages from node
-        :ok = setopts_lib(client).setopts(socket, active: :once)
-
         # Track the caller and query_name, then transition to
         # established_has_agency state prior to sending the query.
         data = update_in(data.queue, &:queue.in({from, query_name}, &1))


### PR DESCRIPTION
Removes redundant code that sets socket to active prior to sending query. This is already taking place at a later stage, immediately prior to sending the message to the socket under the `established_has_agency` state in line 210.

Tested via `elixir run_queries.exs`